### PR TITLE
feat: 휴대폰 인증 번호 전송 및 인증 번호 확인 로직 추가, 기념일에 해당 하는 유저에게 문자 메세지 보내는 로직 추가,

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	//SMS
+	implementation 'net.nurigo:javaSDK:2.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/fiurinee/domain/anniversary/dto/AnniversaryRequestDTO.java
+++ b/src/main/java/com/example/fiurinee/domain/anniversary/dto/AnniversaryRequestDTO.java
@@ -13,4 +13,10 @@ public class AnniversaryRequestDTO {
     private String name;
     private LocalDate date;
     private String type;
+
+    public AnniversaryRequestDTO(String name, LocalDate date, String type) {
+        this.name = name;
+        this.date = date;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/example/fiurinee/domain/jwt/utils/JwtUtils.java
+++ b/src/main/java/com/example/fiurinee/domain/jwt/utils/JwtUtils.java
@@ -52,8 +52,9 @@ public class JwtUtils {
         String socialId = (String) claims.get("socialId");
         String role = (String) claims.get("role");
         Role memberRole = Role.valueOf(role);
+        String phoneNumber = (String) claims.get("phoneNumber");
 
-        MemberDto memberDto = new MemberDto(id, email, name, socialId, memberRole);
+        MemberDto memberDto = new MemberDto(id, email, name, socialId, memberRole,phoneNumber);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(memberDto.role().getValue()));
         PrincipalDetail principalDetail = new PrincipalDetail(memberDto, authorities);
 

--- a/src/main/java/com/example/fiurinee/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/example/fiurinee/domain/member/dto/MemberDto.java
@@ -7,6 +7,7 @@ public record MemberDto(
         String email,
         String name,
         String socialId,
-        Role role
+        Role role,
+        String phoneNumber
 ) {
 }

--- a/src/main/java/com/example/fiurinee/domain/member/entity/Member.java
+++ b/src/main/java/com/example/fiurinee/domain/member/entity/Member.java
@@ -39,6 +39,8 @@ public class Member {
 
     private boolean alarm;
 
+    private String phoneNumber;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @OrderBy("preferOrder ASC")
     private List<PreferList> preferLists;
@@ -65,6 +67,7 @@ public class Member {
         this.kakaoAccessToken = kakaoAccessToken;
         this.profileImage = profileImage;
         this.alarm = alarm;
+        this.phoneNumber = null;
     }
 
     public static Member createMember(String email, String name, String socialId, Role role, String kakaoAccessToken, int profileImage, boolean alarm) {
@@ -78,4 +81,9 @@ public class Member {
     public void updateProfileImage(int profileImage) {
         this.profileImage = profileImage;
     }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
 }

--- a/src/main/java/com/example/fiurinee/domain/member/entity/PrincipalDetail.java
+++ b/src/main/java/com/example/fiurinee/domain/member/entity/PrincipalDetail.java
@@ -34,6 +34,7 @@ public class PrincipalDetail implements UserDetails, OAuth2User {
         info.put("name", memberDto.name());
         info.put("socialId", memberDto.socialId());
         info.put("role", memberDto.role().getValue());
+        info.put("phoneNumber", memberDto.phoneNumber());
         return info;
     }
 

--- a/src/main/java/com/example/fiurinee/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/fiurinee/domain/member/service/MemberService.java
@@ -37,5 +37,11 @@ public class MemberService {
         return MemberResponseDTO.of(member);
     }
 
+    @Transactional
+    public void updatePhoneNumber(Long id, String phoneNumber){
+        Member byId = this.findById(id);
+        byId.updatePhoneNumber(phoneNumber);
+    }
+
 
 }

--- a/src/main/java/com/example/fiurinee/domain/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/com/example/fiurinee/domain/oauth2/service/OAuth2UserService.java
@@ -43,7 +43,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
         Optional<Member> bySocialId = memberRepository.findBySocialId(socialId);
         Member member = bySocialId.orElseGet(() -> saveSocialMember(socialId, name,email, accessToken.getTokenValue()));
         updateAccessToken(member, accessToken.getTokenValue());
-        MemberDto memberDto = new MemberDto(member.getId(), member.getEmail(), member.getName(), member.getSocialId(), member.getRole());
+        MemberDto memberDto = new MemberDto(member.getId(), member.getEmail(), member.getName(), member.getSocialId(), member.getRole(), member.getPhoneNumber());
 
         return new PrincipalDetail(
                 memberDto,

--- a/src/main/java/com/example/fiurinee/domain/sms/controller/SmsController.java
+++ b/src/main/java/com/example/fiurinee/domain/sms/controller/SmsController.java
@@ -1,0 +1,56 @@
+package com.example.fiurinee.domain.sms.controller;
+
+import com.example.fiurinee.domain.anniversary.dto.AnniversaryRequestDTO;
+import com.example.fiurinee.domain.anniversary.entity.Anniversary;
+import com.example.fiurinee.domain.anniversary.service.AnniversaryService;
+import com.example.fiurinee.domain.member.entity.Member;
+import com.example.fiurinee.domain.member.service.MemberService;
+import com.example.fiurinee.domain.sms.controller.api.SmsApi;
+import com.example.fiurinee.domain.sms.dto.CertificateDto;
+import com.example.fiurinee.domain.sms.dto.SmsDto;
+import com.example.fiurinee.domain.sms.service.SmsService;
+import com.example.fiurinee.global.redis.utils.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/sms")
+public class SmsController implements SmsApi {
+
+    private final SmsService smsService;
+    private final RedisUtil redisUtil;
+    private final MemberService memberService;
+    private final AnniversaryService anniversaryService;
+
+    @PostMapping("/send")
+    public void SendSms(@RequestBody SmsDto sms){
+        smsService.certificateSMS(sms.getPhoneNumber());
+    }
+
+    @PostMapping("/prove/{id}")
+    public ResponseEntity<?> certificateSms(@RequestBody CertificateDto dto, @PathVariable("id") Long id){
+        Object o = redisUtil.get(dto.getPhoneNumber());
+
+        if(o.toString().equals(dto.getCertificateNum())){
+            memberService.updatePhoneNumber(id,dto.getPhoneNumber());
+            return ResponseEntity.status(200).build();
+        }
+        else{
+            return ResponseEntity.status(400).build();
+        }
+    }
+
+//    @GetMapping("/test")
+//    public void test(){
+//        Member byId = memberService.findById(1L);
+//        AnniversaryRequestDTO anniversaryRequestDTO = new AnniversaryRequestDTO("이준범 생일", LocalDate.now(), "생일");
+//        Anniversary anniversary = anniversaryService.addAnniversary(1L, anniversaryRequestDTO);
+//        smsService.sendSMS(byId,anniversary);
+//    }
+}

--- a/src/main/java/com/example/fiurinee/domain/sms/controller/api/SmsApi.java
+++ b/src/main/java/com/example/fiurinee/domain/sms/controller/api/SmsApi.java
@@ -1,0 +1,40 @@
+package com.example.fiurinee.domain.sms.controller.api;
+
+import com.example.fiurinee.domain.member.dto.MemberResponseDTO;
+import com.example.fiurinee.domain.sms.dto.CertificateDto;
+import com.example.fiurinee.domain.sms.dto.SmsDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Sms", description = "문자 전송 및 휴대폰 번호 인증 API")
+public interface SmsApi {
+    @Operation(
+            summary = "인증 번호 전송",
+            description = "유저가 입력한 휴대폰 번호로 인증번호를 전송합니다. 인증 번호 만료 시간은 5분 입니다."
+    )
+
+    @ApiResponse(responseCode = "200", description = "성공")
+    @PostMapping("/send")
+    public void SendSms(@RequestBody SmsDto sms);
+
+    @Operation(
+            summary = "유저가 입력한 인증 번호가 일치하는지 확인하는 api",
+            description = "유저가 입력한 인증 번호가 일치하는지 확인하고 일치 한다면 휴대폰 번호를 저장합니다."
+    )
+
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "400", description = "인증 번호가 일치하지 않았어요~~")
+
+    @PostMapping("/prove/{id}")
+    public ResponseEntity<?> certificateSms(@RequestBody CertificateDto dto, @Parameter(description = "유저의 id 입니다.")@PathVariable("id") Long id);
+}

--- a/src/main/java/com/example/fiurinee/domain/sms/dto/CertificateDto.java
+++ b/src/main/java/com/example/fiurinee/domain/sms/dto/CertificateDto.java
@@ -1,0 +1,19 @@
+package com.example.fiurinee.domain.sms.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CertificateDto {
+
+    private String phoneNumber;
+    private String certificateNum;
+
+    public CertificateDto(){}
+
+    public CertificateDto(String phoneNumber, String certificateNum) {
+        this.phoneNumber = phoneNumber;
+        this.certificateNum = certificateNum;
+    }
+}

--- a/src/main/java/com/example/fiurinee/domain/sms/dto/SmsDto.java
+++ b/src/main/java/com/example/fiurinee/domain/sms/dto/SmsDto.java
@@ -1,0 +1,17 @@
+package com.example.fiurinee.domain.sms.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SmsDto {
+
+    private String phoneNumber;
+
+    public SmsDto(){}
+
+    public SmsDto(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/com/example/fiurinee/domain/sms/service/SmsService.java
+++ b/src/main/java/com/example/fiurinee/domain/sms/service/SmsService.java
@@ -1,0 +1,115 @@
+package com.example.fiurinee.domain.sms.service;
+
+import com.example.fiurinee.domain.anniversary.entity.Anniversary;
+import com.example.fiurinee.domain.member.entity.Member;
+import com.example.fiurinee.global.exception.CustomException;
+import com.example.fiurinee.global.redis.utils.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.java_sdk.api.Message;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.json.simple.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+
+    private final RedisUtil redisUtil;
+
+    @Value("${SMS_API_KEY}")
+    private String apiKey;
+
+    @Value("${SMS_SECRET_KEY}")
+    private String apiSecret;
+
+    private String createRandomNumber() {
+        Random rand = new Random();
+        String randomNum = "";
+        for (int i = 0; i < 4; i++) {
+            String random = Integer.toString(rand.nextInt(10));
+            randomNum += random;
+        }
+
+        return randomNum;
+    }
+
+    private HashMap<String, String> makeParams(String to, String randomNum) {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("from", "01051467622");
+        params.put("type", "SMS");
+        params.put("app_version", "Fiurinee 1.0");
+        params.put("to", to);
+        params.put("text", "[Fiurinee] 인증번호"+ "[" + randomNum + "]를 입력해 주세요.");
+        return params;
+    }
+
+    // 인증번호 전송하기
+    @Transactional
+    public void certificateSMS(String phoneNumber) {
+        Message coolsms = new Message(apiKey, apiSecret);
+
+        // 랜덤한 인증 번호 생성
+        String randomNum = createRandomNumber();
+
+        //인증 번호를 redis에 저장 만료시간은 5분
+        redisUtil.set(phoneNumber, randomNum,5);
+
+        // 발신 정보 설정
+        HashMap<String, String> params = makeParams(phoneNumber, randomNum);
+
+        try {
+            JSONObject obj = (JSONObject) coolsms.send(params);
+            System.out.println(obj.toString());
+        } catch (CoolsmsException e) {
+            throw new CustomException(e.getMessage());
+        }
+    }
+
+    @Transactional
+    // 기념일 당일 전송하기
+    public void sendSMS(Member member, Anniversary anniversary) {
+        Message coolsms = new Message(apiKey, apiSecret);
+
+        HashMap<String, String> params = new HashMap<>();
+
+        params.put("from", "01051467622");
+        params.put("type", "SMS");
+        params.put("app_version", "Fiurinee 1.0");
+        params.put("to", member.getPhoneNumber());
+        params.put("text", "[Fiurinee] 안녕하세요 "+ member.getName()+"님!\n오늘은 "+anniversary.getName()+"기념일 입니다!");
+
+        try {
+            JSONObject obj = (JSONObject) coolsms.send(params);
+            System.out.println(obj.toString());
+        } catch (CoolsmsException e) {
+            throw new CustomException(e.getMessage());
+        }
+    }
+
+    @Transactional
+    // 기념일 3일전  전송하기
+    public void preSendSMS(Member member, Anniversary anniversary) {
+        Message coolsms = new Message(apiKey, apiSecret);
+
+        HashMap<String, String> params = new HashMap<>();
+
+        params.put("from", "01051467622");
+        params.put("type", "SMS");
+        params.put("app_version", "Fiurinee 1.0");
+        params.put("to", member.getPhoneNumber());
+        params.put("text", "[Fiurinee] 안녕하세요 "+ member.getName()+"님!\n오늘은 "+anniversary.getName()+"기념일 3일전입니다!");
+
+        try {
+            JSONObject obj = (JSONObject) coolsms.send(params);
+            System.out.println(obj.toString());
+        } catch (CoolsmsException e) {
+            throw new CustomException(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/example/fiurinee/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/fiurinee/global/security/config/SecurityConfig.java
@@ -72,6 +72,8 @@ public class SecurityConfig {
                                 "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**", "/v3/api-docs").permitAll()
                         //비회원 전용 api
                         .requestMatchers("/main/today","/main/season","/model/ment","/model/*/non").permitAll()
+                        //sms api
+                        .requestMatchers("/sms/prove/*","/sms/send").permitAll()
                         .anyRequest().authenticated());
 
         http.addFilterBefore(jwtVerifyFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/fiurinee/global/security/filter/JwtVerifyFilter.java
+++ b/src/main/java/com/example/fiurinee/global/security/filter/JwtVerifyFilter.java
@@ -29,7 +29,9 @@ public class JwtVerifyFilter extends OncePerRequestFilter {
             //Swagger
             "/swagger-ui/index.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/v3/api-docs",
             //비회원 전용 api
-            "/main/today","/main/season","/model/ment","/model/*/non"};
+            "/main/today","/main/season","/model/ment","/model/*/non",
+            //sms api
+            "/sms/prove/*","/sms/send"};
     private final RedisUtil redisUtil;
 
 

--- a/src/main/java/com/example/fiurinee/global/security/handler/CommonLoginSuccessHandler.java
+++ b/src/main/java/com/example/fiurinee/global/security/handler/CommonLoginSuccessHandler.java
@@ -41,7 +41,15 @@ public class CommonLoginSuccessHandler implements AuthenticationSuccessHandler {
         // principal에서 로그인하는 유저의 이메일을 기반으로 refresh 토큰을 redis에 저장
         redisUtil.set(principal.getMemberDto().email(),refreshToken,60*24);
 
-        String redirectUri = "http://localhost:3000/auth";
+        String redirectUri = null;
+
+        if(principal.getMemberDto().phoneNumber() == null) {
+            redirectUri = "http://localhost:3000/phone";
+        }
+        else{
+            redirectUri = "http://localhost:3000/auth";
+        }
+
         Long memberId = principal.getMemberDto().id();
 
         String redirectUrl = String.format("%s?member_id=%d&access_token=%s&refresh_token=%s", redirectUri, memberId, accessToken, refreshToken);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,3 +59,8 @@ cloud:
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
+
+coolsms:
+  apiKey: ${SMS_API_KEY}
+  secretkey: ${SMS_SECRET_KEY}
+


### PR DESCRIPTION
coolsms api를 통해 문자 메세지 전송 구현,
멤버 엔티티에 phoneNumber 추가,
회원가입하는 회원은 휴대폰 인증 페이지로 리다이렉트 이후 휴대폰 인증에 성공하면 데이터베이스에 해당 휴대폰 번호 저장,

기념일인 회원에게 문자 전송하는 서비스는 지현님이 구현한 이메일 전송 로직에 추가시킬 예정